### PR TITLE
chore(deps): bump lints

### DIFF
--- a/lib/linter.yaml
+++ b/lib/linter.yaml
@@ -119,7 +119,6 @@ linter:
     #    - one_member_abstracts
     - only_throw_errors
     - overridden_fields
-    - package_api_docs
     - package_names
     - package_prefixed_library_names
     - parameter_assignments
@@ -182,6 +181,7 @@ linter:
     - type_literal_in_constant_pattern
     - unawaited_futures
     - unnecessary_await_in_return
+    - unnecessary_async
     - unnecessary_brace_in_string_interps
     - unnecessary_breaks
     - unnecessary_const
@@ -197,6 +197,7 @@ linter:
     - unnecessary_null_checks
     - unnecessary_null_in_if_null_operators
     - unnecessary_nullable_for_final_variable_declarations
+    - unnecessary_underscores
     - unnecessary_overrides
     - unnecessary_parenthesis
     - unnecessary_raw_strings
@@ -207,7 +208,7 @@ linter:
     - unnecessary_to_list_in_spreads
     - unreachable_from_main
     - unrelated_type_equality_checks
-    - unsafe_html
+    - unsafe_variance
     - use_build_context_synchronously
     - use_colored_box
     - use_decorated_box

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 repository: https://github.com/Blago-Development/blg_linter
 
 environment:
-  sdk: ^3.3.2
+  sdk: ^3.10.0
 
 dependencies:
-  lints: ^5.0.0
+  lints: ^6.0.0


### PR DESCRIPTION
  # Description

  - Bump Dart SDK constraint to ^3.10.0
  - Upgrade `lints` dependency to ^6.0.0
  - Update enabled lints (add `unnecessary_async`, `unnecessary_underscores`; swap `unsafe_html` for `unsafe_variance`)
  - Remove deprecated/unsupported lint `package_api_docs`

  ## Motivation

  - Align linting with the newer Dart SDK and latest `lints` package
  - Keep lint rules current and remove deprecated rules to avoid warnings or failures